### PR TITLE
Load the JS only in courses the filter is enabled in fixes #3.

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -71,20 +71,23 @@ class filter_syntaxhighlighter extends moodle_text_filter {
         global $CFG;
         static $jsinitialised = false;
 
-        if (empty($jsinitialised)) {
-            $css = get_config('filter_syntaxhighlighter', 'styleurl');
-            $cdn = get_config('filter_syntaxhighlighter', 'cdn');
-            if ($cdn) {
+        // Do this only in the context of a course the filter is enabled in.
+        if (array_key_exists("syntaxhighlighter", filter_get_active_in_context($context))) {
+            if (empty($jsinitialised)) {
+                $css = get_config('filter_syntaxhighlighter', 'styleurl');
+                $cdn = get_config('filter_syntaxhighlighter', 'cdn');
+                if ($cdn) {
                 $css = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/' . $css . '.min.css';
-            } else {
-                $css = $CFG->wwwroot . '/filter/syntaxhighlighter/styles/' . $css . '.min.css';
+                } else {
+                    $css = $CFG->wwwroot . '/filter/syntaxhighlighter/styles/' . $css . '.min.css';
+                }
+                $styleurl = new moodle_url($css);
+
+                $page->requires->js_call_amd('filter_syntaxhighlighter/hljs', 'initHighlighting');
+                $page->requires->css($styleurl);
+
+                $jsinitialised = true;
             }
-            $styleurl = new moodle_url($css);
-
-            $page->requires->js_call_amd('filter_syntaxhighlighter/hljs', 'initHighlighting');
-            $page->requires->css($styleurl);
-
-            $jsinitialised = true;
         }
     }
 }


### PR DESCRIPTION
Previously the initHighlighting JavaScript was called also when the filter was
sitewise set to "Off, but available" and to "Default (Off)" in your course.

Signed-off-by: Luca Bösch <luca.boesch@bfh.ch>