### PR TITLE
Fix Github Actions run.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci codechecker
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Grunt
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt --max-lint-warnings 0
+        run: moodle-plugin-ci grunt -t shifter --max-lint-warnings 0
 
       - name: PHPUnit tests
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# moodle-filter_syntaxhighlighter
+moodle-filter_syntaxhighlighter
+===============================
+
+[![Moodle Plugin CI](https://github.com/sharpchi/moodle-filter_syntaxhighlighter/workflows/Moodle%20Plugin%20CI/badge.svg?branch=master)](https://github.com/sharpchi/moodle-filter_syntaxhighlighter/actions?query=workflow%3A%22Moodle+Plugin+CI%22+branch%3Amaster)
 
 This is a filter plugin that uses a 3rd party Javascript module called [highlight.js](https://highlightjs.org/) to make your code look like something you'd see in an IDE.
 

--- a/filter.php
+++ b/filter.php
@@ -66,7 +66,7 @@ class filter_syntaxhighlighter extends moodle_text_filter {
      * * line break styles (preserve of empty rows in code block)
      * mgrp[2] = "lang:anything;;\r\n"
      * * Specified lang class
-     * mgrp[3] = "anything"     
+     * mgrp[3] = "anything"
      * mgrp[4] = "...code..."
      * mgrp[5] = "</pre>"
      *


### PR DESCRIPTION
This will turn the Github actions green and also show the result on the README.

I had to remove  --max-warnings 0 from codechecker since you have to use backticks in strings and they do cause a warning.
I had to specifically have run only grunt shifter to avoid grunt amd to circumvent checking your external libraries.
Fixed a trailing whitespace.

Best,
Luca